### PR TITLE
Fixed livereload happening too early by making tasks async for runSequen...

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -19,7 +19,7 @@ gulp.task('connect', function () {
 });
 
 gulp.task('html', function () {
-	gulp.src('./public/*.html')
+	return gulp.src('./public/*.html')
 		.pipe(connect.reload());
 });
 
@@ -52,14 +52,20 @@ gulp.task('clean', function (callback) {
 });
 
 gulp.task('build-sass', function () {
-	gulp.src('./src/**/*.scss')
-		.pipe(sass())
-		.pipe(concat('components.css'))
-		.pipe(gulp.dest('./public/css'));
 
-	gulp.src('./node_modules/zurb-foundation-5/scss/*.scss')
-		.pipe(sass())
-		.pipe(gulp.dest('./public/css/foundation'));
+	return mergeStream(
+
+		gulp.src('./src/**/*.scss')
+			.pipe(sass())
+			.pipe(concat('components.css'))
+			.pipe(gulp.dest('./public/css')),
+
+		gulp.src('./node_modules/zurb-foundation-5/scss/*.scss')
+			.pipe(sass())
+			.pipe(gulp.dest('./public/css/foundation'))
+
+	);
+
 });
 
 gulp.task('ractive-build-templates', function () {


### PR DESCRIPTION
On my laptop, file changes would effect a page refresh before css was finished generating.

Adding the `clean` task made this problem obvious (which is a good thing).

The reason was that `build-sass` gulp task was not returning anything - tasks should be async as per docs:

https://github.com/gulpjs/gulp/blob/master/docs/API.md
