### PR TITLE
Created gulp dist task, builds first.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 bower_components
 node_modules
 .tmp
-dist
 *.log
 logs
 .DS_Store

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -181,6 +181,15 @@ gulp.task('build', ['clean', 'jshint'], function (callback) {
 	], callback);
 });
 
+gulp.task('dist', ['build'], function () {
+	return gulp.src([
+		'public/js/ractivef-amd.js',
+		'public/js/ractivef-base.js',
+		'public/js/ractivef-cjs.js',
+		'public/css/components.css'
+	]).pipe(gulp.dest('dist'));
+});
+
 gulp.task('watch', function () {
 	var self = this;
 	plugins.watch([


### PR DESCRIPTION
Much discussion about best way to distribute a package like RF.

For now, we've gone with a /dist folder, which is ONLY built in master for now.

Run `gulp dist`, commit, tag and push that "release" to github.

Later we can sort out the best distro strategy for npm.
