### PR TITLE
[LUX-77] - Generated component pages now display the use case data

### DIFF
--- a/tasks/renderDocumentation.js
+++ b/tasks/renderDocumentation.js
@@ -88,8 +88,15 @@ function renderUseCases(useCase, componentName) {
 				tag: 'code',
 				content: _.escape(makeHTML([componentObj]))
 			}]
-		}
-	]).replace(/(\r\n|\n|\r)/gm, '');
+		},
+		{
+        	tag: 'pre',
+        	content: [{
+        		tag: 'code',
+        		content: JSON.stringify(useCase.data, null, 4)
+        	}]
+       	}
+	]).replace(/(\r\n|\r)/gm, '');
 
 	return component;
 


### PR DESCRIPTION
newline (\n) has been removed from the regex in makeHTML().replace in order to preserve the useCase's JSON formatting. 
