### PR TITLE
Clean up and support for tags

### DIFF
--- a/tasks/rfCucumber.js
+++ b/tasks/rfCucumber.js
@@ -30,7 +30,7 @@ module.exports = function (options) {
 	if (options.tags) {
 		tags = ['--tags', options.tags];
 		if (_.isArray(options.tags)) {
-			if (options.requireBothTags) {
+			if (options.requireAllTags) {
 				tags = _(options.tags)
 					.map(function (tag) {
 						return ['--tags', tag]

--- a/tasks/seleniumServer.js
+++ b/tasks/seleniumServer.js
@@ -38,7 +38,7 @@ module.exports = function (options) {
 				resolve(isSeleniumServerRunning);
 			}).on('error', function() {
 				gutil.log(gutil.colors.gray('Selenium server is not running'));
-				resolve('Server not running');
+				resolve();
 			});
 		});
 	};
@@ -117,11 +117,15 @@ module.exports = function (options) {
 	};
 
 	var init = function () {
-		return pingSelenium(options).then(function () {
-			return options.install ? installDrivers(seleniumInstallOptions) : Q.resolve();
-		}).then(function () {
-			return startServer(seleniumOptions);
+
+		var promise = options.install ? installDrivers(seleniumInstallOptions) : Q.resolve();
+
+		return promise.then(function () {
+			return pingSelenium(options);
+		}).then(function (isServerRunning) {
+			return isServerRunning ? Q.resolve() : startServer(seleniumOptions);
 		});
+
 	};
 
 	return {


### PR DESCRIPTION
- Added support for tags, based on two scenarios here: https://github.com/cucumber/cucumber/wiki/Tags 
  - We can backlog a task to cater for all tag scenarios (e.g. `cucumber --tags @billing,@wip --tags @important`)
- Clean up comments and variables names
- Re-wrote init function for selenium, it would attempt to start selenium every time even if the check returned true.
