### PR TITLE
Fixed version check which fails for node v4.0.0

### DIFF
--- a/bin/versionCheck.js
+++ b/bin/versionCheck.js
@@ -1,6 +1,7 @@
 const MINIMUM_VERSION = '0.12.0';
 
 var compareVersions = function (installed, required) {
+	installed = installed.replace(/^v/, '');
 	var a = installed.split('.');
 	var b = required.split('.');
 
@@ -14,6 +15,7 @@ var compareVersions = function (installed, required) {
 		a[2] = 0;
 	}
 
+    process.stdout.write(a[0] + ' > ' + b[0] + ' = ' + (a[0] > b[0]));
 	if (a[0] > b[0]) return true;
 	if (a[0] < b[0]) return false;
 

--- a/bin/versionCheck.js
+++ b/bin/versionCheck.js
@@ -15,7 +15,6 @@ var compareVersions = function (installed, required) {
 		a[2] = 0;
 	}
 
-    process.stdout.write(a[0] + ' > ' + b[0] + ' = ' + (a[0] > b[0]));
 	if (a[0] > b[0]) return true;
 	if (a[0] < b[0]) return false;
 


### PR DESCRIPTION
Node version 4.0.0 returns the version number with a v at the front of the version string.
