### PR TITLE
Keystrokes tweaks

### DIFF
--- a/src/components/ux-keystrokes/manifest.json
+++ b/src/components/ux-keystrokes/manifest.json
@@ -2,5 +2,5 @@
 	"data": {
 		"text": "The text to display on the ux-keystrokes component"
 	},
-	"category": "Typography"
+	"category": "typography"
 }

--- a/src/components/ux-keystrokes/use-cases/customAtributes.json
+++ b/src/components/ux-keystrokes/use-cases/customAtributes.json
@@ -1,5 +1,6 @@
 {
 	"title": "Use case with custom attributes",
+	"isDataModel": true,
 	"data": {
 		"text": "Cmd"
 	}

--- a/src/components/ux-keystrokes/ux-keystrokes.hbs
+++ b/src/components/ux-keystrokes/ux-keystrokes.hbs
@@ -1,7 +1,7 @@
 <kbd>
-    {{#if isDataModel}}
-        {{text}}
-    {{else}}
-        {{yield}}
-    {{/if}}
+	{{#if isDataModel}}
+		{{text}}
+	{{else}}
+		{{yield}}
+	{{/if}}
 </kbd>

--- a/src/components/ux-keystrokes/ux-keystrokes.js
+++ b/src/components/ux-keystrokes/ux-keystrokes.js
@@ -1,3 +1,4 @@
 Ractive.extend({
+	isolated: true,
 	template: Ractive.defaults.templates['ux-keystrokes']
 });


### PR DESCRIPTION
A few fixes:
- Isolated component (@ivanwills, talking point for @nathf)
- Lowercase category names (Indra aware of this now?)
- Spaces to tabs
- Added `isDataModel` boolean to mock
