### PR TITLE
#288 Add two new options to cater for new scenarios.

### DIFF
--- a/tasks/seleniumServer.js
+++ b/tasks/seleniumServer.js
@@ -24,6 +24,11 @@ module.exports = function (options) {
 	var pingSelenium = function(options) {
 		options = options || {};
 		return Q.Promise(function (resolve, reject) {
+
+			if (options.seleniumOptions && options.seleniumOptions.alwaysSpawn) {
+				return resolve(false);
+			}
+
 			gutil.log(gutil.colors.gray('Checking if Selenium server is running'));
 
 			var opts = {
@@ -79,6 +84,11 @@ module.exports = function (options) {
 			if (!seleniumServer) {
 				gutil.log(gutil.colors.red('Cannot kill standalone server.'));
 				return reject('Cannot kill standalone server.');
+			}
+
+			if (options.seleniumOptions.kill === false) {
+				gutil.log('Finished', '\'' + gutil.colors.cyan('selenium standalone server') + '\'...');
+				return reject('Configured not to kill selenium.')
 			}
 
 			seleniumServer.kill();

--- a/tasks/seleniumServer.js
+++ b/tasks/seleniumServer.js
@@ -87,8 +87,9 @@ module.exports = function (options) {
 			}
 
 			if (options.seleniumOptions.kill === false) {
+				gutil.log(gutil.colors.green('Configured not to kill selenium.'))
 				gutil.log('Finished', '\'' + gutil.colors.cyan('selenium standalone server') + '\'...');
-				return reject('Configured not to kill selenium.')
+				return resolve();
 			}
 
 			seleniumServer.kill();


### PR DESCRIPTION
alwaysSpawn: boolean true|false - If so true will always return isServerRunning as false, to force a server start.
kill: boolean true|false - Set to false to never kill the selenium server at the end.
