### PR TITLE
#341: ux-modal responsiveness improvements, bug fixes

### DIFF
--- a/src/components/ux-reveal/ux-reveal.js
+++ b/src/components/ux-reveal/ux-reveal.js
@@ -10,8 +10,12 @@ Ractive.extend({
 	oninit: function () {
 		this.on('toggleModal', function (e) {
 			this.set('modalVisible', !this.get('modalVisible'));
-			document.body.style.overflow = (this.get('modalVisible')) ? 'hidden' : 'auto';
 			this.fire('toggleReveal', e);
+			return false;
+		});
+
+		this.observe('modalVisible', function (newValue, oldValue, keypath) {
+			document.body.style.overflow = (newValue === true) ? 'hidden' : 'auto';
 			return false;
 		});
 	}

--- a/src/components/ux-reveal/ux-reveal.scss
+++ b/src/components/ux-reveal/ux-reveal.scss
@@ -2,8 +2,18 @@
 
 	.reveal-modal {
 		position: fixed;
-		max-height: 80%;
 		overflow-y: auto;
+		top: 0;
+		left: 0;
+		bottom: 0;
+		right: 0;
+
+		@media only screen and (min-width: 40.0625em) {
+			top: 10%;
+			left: 20%;
+			bottom: 10%;
+			right: 20%;
+		}
 	}
 
 	.modal-visible {


### PR DESCRIPTION
Sets the modal to a fixed size in desktop view, explicitly defines size in mobile view. Should fix issues with text overflow and scrolling. 
Background overflow is now controlled through an observer, this allows the background overflow to respond to programmatically altering the modal visibility.
