### PR TITLE
Adding name to ux-flex-video for screen-readers

### DIFF
--- a/src/components/ux-flex-video/manifest.json
+++ b/src/components/ux-flex-video/manifest.json
@@ -5,7 +5,8 @@
     "frameborder": "Frameborder of the iframe",
     "height": "Height of the iframe",
     "src": "Source URL for the video. e.g. //www.youtube.com/embed/aiBt44rrslw",
-    "width": "Width of the iframe"
+    "width": "Width of the iframe",
+    "name": "Name of the video - a screen reader will use this to describe the video"
   },
   "category": "media"
 }

--- a/src/components/ux-flex-video/use-cases/accessibility.json
+++ b/src/components/ux-flex-video/use-cases/accessibility.json
@@ -1,0 +1,13 @@
+{
+	"title": "Basic Flex Video",
+	"isDataModel": true,
+	"data": {
+		"allowfullscreen": "allowfullscreen",
+		"class": "",
+		"frameborder": "0",
+		"height": "315",
+		"src": "//www.youtube.com/embed/YE7VzlLtp-4",
+		"width": "420",
+		"name": "Big Buck Bunny"
+	}
+}

--- a/src/components/ux-flex-video/ux-flex-video.feature
+++ b/src/components/ux-flex-video/ux-flex-video.feature
@@ -15,3 +15,8 @@ Feature: ux-flex-video test suite
 		And the element "iframe" should have attribute "frameborder" containing "0"
 		And the element "flexvideo" will have the class "widescreen"
 		And the element "flexvideo" will have the class "vimeo"
+
+	Scenario: Loading ux-flex-video accessibility
+		Given I have loaded component "ux-flex-video" with use case "accessibility"
+		Then there will be an element for "iframe"
+		And the element "iframe" should have attribute "name" containing "Big Buck Bunny"

--- a/src/components/ux-flex-video/ux-flex-video.hbs
+++ b/src/components/ux-flex-video/ux-flex-video.hbs
@@ -6,6 +6,7 @@
 			height="{{height}}"
 			width="{{width}}"
 			frameborder="{{frameborder}}"
+			name="{{name}}"
 			{{#allowfullscreen}} {{allowfullscreen}}{{/}}>
 		</iframe>
 	</div>


### PR DESCRIPTION
The flex video is nested in an unlabelled frame. As such, via screen reader, the frame reads as "Frame 0", which does not provide visually impaired users with enough information to decide where to inspect what is contained within the frame.

The 'name' property allows authors to give some context to videos for screen readers. 