### PR TITLE
Removed innerClick handler from ux-reveal

### DIFF
--- a/src/components/ux-reveal/ux-reveal.hbs
+++ b/src/components/ux-reveal/ux-reveal.hbs
@@ -3,13 +3,11 @@
 		on-tap="toggleModal"
 		class="open-reveal-modal">{{text}}</a>
 
-	<div class="reveal-modal-bg {{#if modalVisible}}modal-visible{{/if}}"
-		aria-hidden="false"
-		on-tap="closeOnBgClick"></div>
-
+	<div class="ux-reveal-wrapper">
+		<div class="reveal-modal-bg {{#if modalVisible}}modal-visible{{/if}}"
+			on-tap="closeOnBgClick"></div>
 		<div class="reveal-modal {{size}} {{#if modalVisible}}modal-visible{{/if}}"
-			aria-hidden="{{modalVisible}}"
-			on-tap="innerClick">
+			aria-hidden="{{modalVisible}}">
 			{{#if isDataModel}}
 				{{{content}}}
 			{{else}}
@@ -22,4 +20,5 @@
 					on-tap="toggleModal">{{{closetext}}}</a>
 			{{/if}}
 		</div>
+	</div>
 </div>

--- a/src/components/ux-reveal/ux-reveal.js
+++ b/src/components/ux-reveal/ux-reveal.js
@@ -17,11 +17,6 @@ Ractive.extend({
 			return false;
 		});
 
-		this.on('innerClick', function (e) {
-			// captures clicks inside the modal, to prevent event propagation from closing the modal.
-			return false;
-		});
-
 		this.observe('modalVisible', function (newValue, oldValue, keypath) {
 			document.body.style.overflow = (newValue === true) ? 'hidden' : 'auto';
 

--- a/src/components/ux-reveal/ux-reveal.scss
+++ b/src/components/ux-reveal/ux-reveal.scss
@@ -1,10 +1,13 @@
 .ux-reveal {
+	position: relative;
 
-	position: fixed;
-	width: 100%;
-	left: 0;
-	top: 0;
-	z-index: 1002;
+	.ux-reveal-wrapper {
+		position: fixed;
+		width: 100%;
+		left: 0;
+		top: 0;
+		z-index: 1002;
+	}
 
 	.modal-visible {
 		display: block;
@@ -12,7 +15,7 @@
 	}
 
 	.reveal-modal {
-		position: absolute;
+		position: fixed;
 		z-index: 1005;
 
 		.close-reveal-modal {


### PR DESCRIPTION
- Removed `innerClick` handler that was no longer in use after the background was isolated from the content.
- Removed `position: fixed` from the root element, so that the link to open the model remain positions correctly. Created a fixed wrapper instead that contains the background and content.