### PR TITLE
Used Ractive's find() to access the DOM element instead of document.q…

### DIFF
--- a/src/components/ux-joyride/ux-joyride.js
+++ b/src/components/ux-joyride/ux-joyride.js
@@ -133,7 +133,7 @@ Ractive.extend({
 
 	focusJoyride: function (joyrideTarget) {
 		//TODO: smooth scolling?
-		var joyride = document.querySelector(joyrideTarget).getBoundingClientRect();
+		var joyride = this.find(joyrideTarget).getBoundingClientRect();
 		var absoluteElementTop = joyride.top + window.pageYOffset;
 		var middle = absoluteElementTop - (window.innerHeight / 2);
 		window.scrollTo(0, middle);


### PR DESCRIPTION
Used Ractive's find() to access the DOM element instead of `document.querySelector()`, which may result in the element outside the component.